### PR TITLE
feat: add netcoredbg debugging and neotest for .NET

### DIFF
--- a/.config/nvim/after/plugin/debugger.lua
+++ b/.config/nvim/after/plugin/debugger.lua
@@ -20,9 +20,16 @@ local function joinpath(...)
 end
 
 
+local netcoredbg_cmd
+if vim.fn.has("win32") == 1 then
+    netcoredbg_cmd = vim.fn.stdpath("data") .. '\\mason\\packages\\netcoredbg\\netcoredbg\\netcoredbg.exe'
+else
+    netcoredbg_cmd = os.getenv("HOME") .. '/.local/netcoredbg/netcoredbg/netcoredbg'
+end
+
 dap.adapters.coreclr = {
     type = 'executable',
-    command = os.getenv("HOME") .. '/.local/netcoredbg/netcoredbg/netcoredbg',
+    command = netcoredbg_cmd,
     args = { '--interpreter=vscode' }
 }
 
@@ -31,6 +38,7 @@ dap.configurations.cs = {
         type = 'coreclr',
         name = 'Launch',
         request = 'launch',
+        cwd = function() return vim.fn.getcwd() end,
         program = function()
             local cwd = vim.fn.getcwd()
             local csproj_files = {}
@@ -59,18 +67,30 @@ dap.configurations.cs = {
             local csproj_path = joinpath(cwd, csproj_file)
             local target_framework = get_target_framework(csproj_path)
 
-            local build_result = vim.fn.system('dotnet build')
-            if vim.v.shell_error ~= 0 then
+            local build_result = vim.fn.system('dotnet build -nologo --verbosity quiet 2>&1')
+            -- shell_error can be unreliable with dotnet CLI, check output instead
+            if build_result:match("Build FAILED") then
                 error("Build failed: " .. build_result)
             end
 
             local dll_path = joinpath(cwd, "bin", "Debug", target_framework, project_name .. ".dll")
             if vim.fn.filereadable(dll_path) == 0 then
-                error("DLL not found: " .. dll_path)
+                local exe_path = joinpath(cwd, "bin", "Debug", target_framework, project_name .. ".exe")
+                if vim.fn.filereadable(exe_path) == 0 then
+                    error("DLL/EXE not found: " .. dll_path)
+                end
+                dll_path = exe_path
             end
 
             return dll_path
         end,
+        stopAtEntry = true,
+    },
+    {
+        type = 'coreclr',
+        name = 'Attach to Process',
+        request = 'attach',
+        processId = require('dap.utils').pick_process,
     },
 }
 

--- a/.config/nvim/after/plugin/neotest.lua
+++ b/.config/nvim/after/plugin/neotest.lua
@@ -1,0 +1,35 @@
+local neotest = require("neotest")
+
+neotest.setup({
+    adapters = {
+        require("neotest-dotnet")({
+            dap = {
+                adapter_name = "coreclr",
+            },
+            discovery_root = "project",
+        }),
+    },
+    discovery = {
+        enabled = true,
+    },
+})
+
+-- Auto-discover tests when opening a C# file
+vim.api.nvim_create_autocmd("BufEnter", {
+    pattern = "*.cs",
+    callback = function()
+        local cwd = vim.fn.getcwd()
+        local csproj = vim.fn.glob(cwd .. "/*.csproj")
+        if csproj ~= "" then
+            neotest.run.run(cwd)
+        end
+    end,
+    once = true,
+})
+
+vim.keymap.set("n", "<leader>tr", function() neotest.run.run() end, { desc = "Run nearest test" })
+vim.keymap.set("n", "<leader>tf", function() neotest.run.run(vim.fn.expand("%")) end, { desc = "Run all tests in file" })
+vim.keymap.set("n", "<leader>td", function() neotest.run.run({ strategy = "dap" }) end, { desc = "Debug nearest test" })
+vim.keymap.set("n", "<leader>ts", function() neotest.summary.toggle() end, { desc = "Toggle test summary" })
+vim.keymap.set("n", "<leader>to", function() neotest.output.open({ enter = true }) end, { desc = "Show test output" })
+vim.keymap.set("n", "<leader>tp", function() neotest.output_panel.toggle() end, { desc = "Toggle output panel" })

--- a/.config/nvim/lua/kx0101/packer.lua
+++ b/.config/nvim/lua/kx0101/packer.lua
@@ -57,6 +57,16 @@ return require('packer').startup(function(use)
 
     use { "folke/neodev.nvim", opts = {} }
 
+    use {
+        "nvim-neotest/neotest",
+        requires = {
+            "nvim-neotest/nvim-nio",
+            "nvim-lua/plenary.nvim",
+            "nvim-treesitter/nvim-treesitter",
+            "Issafalcon/neotest-dotnet",
+        },
+    }
+
     use { "rcarriga/nvim-dap-ui", requires = { "mfussenegger/nvim-dap", "nvim-neotest/nvim-nio" } }
 
     use({

--- a/.config/nvim/lua/kx0101/remap.lua
+++ b/.config/nvim/lua/kx0101/remap.lua
@@ -50,7 +50,6 @@ vim.keymap.set("n", "<C-k>", "<C-w>k")
 vim.keymap.set("n", "<C-l>", "<C-w>l")
 
 vim.opt.clipboard = "unnamedplus"
-vim.opt.shell = "/bin/bash"
 
 -- vim.g.clipboard = {
 --     name = "xclip-xfce4-clipman",

--- a/.config/nvim/lua/kx0101/set.lua
+++ b/.config/nvim/lua/kx0101/set.lua
@@ -1,3 +1,17 @@
+vim.opt.termguicolors = true
+
+if vim.fn.has("win32") == 1 then
+    vim.opt.shell = "cmd.exe"
+    vim.opt.shellcmdflag = "/s /c"
+    vim.opt.shellquote = ""
+    vim.opt.shellxquote = "("
+else
+    vim.opt.shell = "/usr/bin/zsh"
+    vim.opt.shellcmdflag = "-c"
+    vim.opt.shellquote = ""
+    vim.opt.shellxquote = ""
+end
+
 vim.opt.guicursor = ""
 
 vim.opt.nu = true


### PR DESCRIPTION
- Cross-platform netcoredbg path (Mason on Windows, ~/.local on Linux)
- Add cwd and stopAtEntry to launch config for reliable breakpoints
- Fix build check to use output matching instead of shell_error
- Add exe fallback for .NET Framework builds
- Add attach-to-process debug configuration
- Add neotest + neotest-dotnet for test running
- Add platform-conditional shell settings (cmd.exe on Windows)
- Remove hardcoded /bin/bash shell override from remap.lua