### PR TITLE
[macOS] Apple Silicon support alongside Linux

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -19,7 +19,9 @@ bind-key C-p switch-client -p
 setw -g mode-keys vi
 
 bind -T copy-mode-vi v send-keys -X begin-selection
-bind -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "xclip -selection clipboard -i"
+if-shell "uname | grep -q Darwin" \
+    'bind -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "pbcopy"' \
+    'bind -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "xclip -selection clipboard -i"'
 
 bind r source-file $HOME/.tmux.conf \; display-message "tmux.conf sourced"
 

--- a/.zshrc
+++ b/.zshrc
@@ -17,18 +17,29 @@ alias dotfiles="cd ~/personal/.dotfiles"
 
 # Environment Variables
 
-# Set up tool-specific roots
-export GOROOT="/usr/local/go"
+# Cross-platform tool roots and paths
 export GOPATH="$HOME/go"
-
-# Prepend development tool paths
-export PATH="$HOME/.cargo/bin:$HOME/.local/bin:/usr/local/bin/node:$GOROOT/bin:$GOPATH/bin:$PATH"
-export PATH=/opt/zig:$PATH
-export PATH="$PATH:/home/elijahkx/.dotnet/tools"
-export PATH="$HOME/vcpkg:$PATH"
 export VCPKG_ROOT="$HOME/vcpkg"
-export DOTNET_ROOT=$HOME/.dotnet
-export PATH=$HOME/.dotnet:$PATH
+export DOTNET_ROOT="$HOME/.dotnet"
 
-export http_proxy=http://192.168.1.6:808
-export https_proxy=http://192.168.1.6:808
+export PATH="$HOME/.cargo/bin:$HOME/.local/bin:$HOME/.local/npm/bin:$GOPATH/bin:$PATH"
+export PATH="$HOME/vcpkg:$PATH"
+export PATH="$HOME/.dotnet:$HOME/.dotnet/tools:$PATH"
+
+case "$(uname -s)" in
+    Darwin)
+        # Homebrew (Apple Silicon) puts go/node/zig and friends on PATH
+        if [ -x /opt/homebrew/bin/brew ]; then
+            eval "$(/opt/homebrew/bin/brew shellenv)"
+        fi
+        ;;
+    *)
+        # Linux
+        export GOROOT="/usr/local/go"
+        export PATH="$GOROOT/bin:/usr/local/bin/node:/opt/zig:$PATH"
+
+        # Home/work network proxy (Linux box only)
+        export http_proxy=http://192.168.1.6:808
+        export https_proxy=http://192.168.1.6:808
+        ;;
+esac

--- a/dev-env
+++ b/dev-env
@@ -60,8 +60,14 @@ execute mkdir -p $HOME/.config/nvim
 copy_dir nvim $HOME/.config/nvim
 copy_file nvim/init.lua $HOME/.config/nvim
 
+execute mkdir -p $HOME/.config/ghostty
 copy_file config $HOME/.config/ghostty
 copy_file .tmux.conf $HOME
 copy_file .ideavimrc $HOME
 copy_file .zshrc $HOME
 copy_file dev-env $HOME/.local/bin
+
+if [[ "$(uname -s)" == "Darwin" ]]; then
+    execute mkdir -p $HOME/.hammerspoon
+    copy_file hammerspoon/init.lua $HOME/.hammerspoon
+fi

--- a/hammerspoon/init.lua
+++ b/hammerspoon/init.lua
@@ -1,0 +1,38 @@
+-- ~/.hammerspoon/init.lua
+-- Global launch-or-focus shortcuts, ported from the Windows AutoHotkey setup
+-- (shortcuts.ahk). On macOS, Alt is the Option (⌥) key.
+
+-- ⌥ Option is the macOS analog of Alt on Windows/Linux.
+local mod = { "alt" }
+
+-- Edit the values to match the app names as they appear in /Applications.
+local apps = {
+    q = "Google Chrome", -- ⌥Q  browser
+    w = "Ghostty",       -- ⌥W  terminal
+    e = "Slack",         -- ⌥E  Slack
+    r = "Discord",       -- ⌥R  Discord
+    f = "Spotify",       -- ⌥F  Spotify
+}
+
+for key, appName in pairs(apps) do
+    hs.hotkey.bind(mod, key, function()
+        hs.application.launchOrFocus(appName)
+    end)
+end
+
+-- Reload config manually (⌥⌃R) and automatically when this file changes.
+hs.hotkey.bind({ "alt", "ctrl" }, "r", function()
+    hs.reload()
+end)
+
+local function reloadConfig(files)
+    for _, file in pairs(files) do
+        if file:sub(-4) == ".lua" then
+            hs.reload()
+            return
+        end
+    end
+end
+
+hs.pathwatcher.new(os.getenv("HOME") .. "/.hammerspoon/", reloadConfig):start()
+hs.alert.show("Hammerspoon config loaded")

--- a/runs/ai-clis
+++ b/runs/ai-clis
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -e
+
+# GitHub Copilot CLI + Anthropic Claude Code CLI (both distributed via npm).
+# Your Neovim already uses github/copilot.vim; these are the standalone terminal
+# agents.
+
+# Ensure npm exists (the node run-script normally installs it first).
+if ! command -v npm > /dev/null 2>&1; then
+    case "$(uname -s)" in
+        Darwin)
+            brew install node
+            ;;
+        *)
+            echo "npm not found. Run ./runs/node first, then re-run ./runs/ai-clis."
+            exit 1
+            ;;
+    esac
+fi
+
+echo "Installing GitHub Copilot CLI and Claude Code CLI..."
+npm install -g @github/copilot @anthropic-ai/claude-code
+
+# gh is handy for Copilot auth and general GitHub work.
+if ! command -v gh > /dev/null 2>&1 && [ "$(uname -s)" = "Darwin" ]; then
+    brew install gh
+fi
+
+echo "Done. Authenticate with: copilot   and   claude"

--- a/runs/docker
+++ b/runs/docker
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+if [ "$(uname -s)" = "Darwin" ]; then
+    brew install --cask docker-desktop
+    exit 0
+fi
+
 sudo apt-get -y update
 sudo apt-get -y install ca-certificates curl
 sudo install -m 0755 -d /etc/apt/keyrings

--- a/runs/font
+++ b/runs/font
@@ -1,6 +1,25 @@
 #!/usr/bin/env bash
 set -e
 
+if [ "$(uname -s)" = "Darwin" ]; then
+    echo "Installing Nerd Fonts via Homebrew..."
+    fonts=(
+        font-hack-nerd-font
+        font-fira-code-nerd-font
+        font-caskaydia-cove-nerd-font
+        font-sauce-code-pro-nerd-font
+        font-agave-nerd-font
+        font-jetbrains-mono-nerd-font
+        font-iosevka-term-nerd-font
+        font-iosevka-term-slab-nerd-font
+    )
+    for f in "${fonts[@]}"; do
+        brew install --cask "$f" || echo "  (skipped $f)"
+    done
+    echo "All fonts installed successfully"
+    exit 0
+fi
+
 FONT_DIR="$HOME/.local/share/fonts"
 mkdir -p "$FONT_DIR"
 cd "$FONT_DIR"

--- a/runs/ghostty
+++ b/runs/ghostty
@@ -2,6 +2,11 @@
 
 set -e
 
+if [ "$(uname -s)" = "Darwin" ]; then
+    brew install --cask ghostty
+    exit 0
+fi
+
 ZIG_VERSION="0.13.0"
 GHOSTTY_REPO="https://github.com/mitchellh/ghostty.git"
 

--- a/runs/git
+++ b/runs/git
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 
-sudo apt install -y git
+case "$(uname -s)" in
+    Darwin) brew install git ;;
+    *) sudo apt install -y git ;;
+esac
 
 git config --global user.email "liakos.koulaxis@yahoo.com"
 git config --global user.name "kx0101"

--- a/runs/go
+++ b/runs/go
@@ -4,7 +4,14 @@ version="1.25.0"
 
 echo "go version: $version"
 
-wget https://go.dev/dl/go$version.linux-amd64.tar.gz -O go.tar.gz
-sudo rm -rf /usr/local/go
-sudo tar -C /usr/local -xzf go.tar.gz
-rm go.tar.gz
+case "$(uname -s)" in
+    Darwin)
+        brew install go
+        ;;
+    *)
+        wget https://go.dev/dl/go$version.linux-amd64.tar.gz -O go.tar.gz
+        sudo rm -rf /usr/local/go
+        sudo tar -C /usr/local -xzf go.tar.gz
+        rm go.tar.gz
+        ;;
+esac

--- a/runs/libs
+++ b/runs/libs
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 
+if [ "$(uname -s)" = "Darwin" ]; then
+    # pbcopy replaces xclip; pavucontrol/shutter are Linux-only GUI tools
+    # gnupg is needed because .gitconfig sets commit.gpgsign = true
+    brew install ripgrep jq tldr fzf gh python@3.13 gnupg
+    "$(brew --prefix)/opt/fzf/install" --all --no-update-rc || true
+    exit 0
+fi
+
 sudo apt -y update
 sudo apt -y install git ripgrep pavucontrol xclip jq tldr shutter python3-pip
 

--- a/runs/neovim
+++ b/runs/neovim
@@ -4,6 +4,13 @@ version="v0.12.0"
 
 echo "version: \"$version\""
 
+if [ "$(uname -s)" = "Darwin" ]; then
+    brew install neovim luarocks
+    luarocks install luasocket || true
+    luarocks install luacheck || true
+    exit 0
+fi
+
 if [ ! -d $HOME/neovim ]; then
     git clone https://github.com/neovim/neovim.git $HOME/neovim
 fi

--- a/runs/netcoredbg
+++ b/runs/netcoredbg
@@ -1,6 +1,19 @@
 #!/usr/bin/env bash
 
+case "$(uname -s)" in
+    Darwin)
+        ASSET="netcoredbg-osx-amd64.tar.gz"
+        # The macOS build is x64-only; ensure Rosetta on Apple Silicon
+        if [ "$(uname -m)" = "arm64" ]; then
+            softwareupdate --install-rosetta --agree-to-license || true
+        fi
+        ;;
+    *)
+        ASSET="netcoredbg-linux-amd64.tar.gz"
+        ;;
+esac
+
 mkdir -p "$HOME/.local/netcoredbg"
 cd "$HOME/.local/netcoredbg"
-wget https://github.com/Samsung/netcoredbg/releases/latest/download/netcoredbg-linux-amd64.tar.gz -O netcoredbg.tar.gz
+curl -fL "https://github.com/Samsung/netcoredbg/releases/latest/download/$ASSET" -o netcoredbg.tar.gz
 tar -xzf netcoredbg.tar.gz && rm netcoredbg.tar.gz

--- a/runs/node
+++ b/runs/node
@@ -1,9 +1,16 @@
 #!/usr/bin/env bash
 
-sudo apt install nodejs npm
-npm config set prefix ~/.local/npm
-npm i -g n
-n lts
+case "$(uname -s)" in
+    Darwin)
+        brew install node
+        ;;
+    *)
+        sudo apt install nodejs npm
+        npm config set prefix ~/.local/npm
+        npm i -g n
+        n lts
+        ;;
+esac
 
 curl -fsSL https://deno.land/install.sh | sh
 curl -fsSL https://bun.sh/install | bash

--- a/runs/ollama
+++ b/runs/ollama
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -e
+
+# Local coding model for Ollama. qwen2.5-coder:32b (~20GB, Q4_K_M) is one of the
+# strongest local coding models and fits comfortably in 48GB unified memory.
+# Override with: OLLAMA_MODEL=<name> ./runs/ollama
+# Other good options:
+#   qwen2.5-coder:14b / :7b   (smaller, faster)
+#   qwen3-coder:30b           (newer MoE, very fast)
+#   deepseek-coder-v2:16b
+MODEL="${OLLAMA_MODEL:-qwen2.5-coder:32b}"
+
+case "$(uname -s)" in
+    Darwin)
+        if ! command -v ollama > /dev/null 2>&1; then
+            # CLI + server. For the menu-bar app instead: brew install --cask ollama-app
+            brew install ollama
+        fi
+        ;;
+    *)
+        if ! command -v ollama > /dev/null 2>&1; then
+            curl -fsSL https://ollama.com/install.sh | sh
+        fi
+        ;;
+esac
+
+# Make sure the server is reachable before pulling (Linux installer registers a
+# systemd service; on macOS the formula needs a manual `ollama serve`).
+if ! curl -fsS http://localhost:11434/api/tags > /dev/null 2>&1; then
+    echo "Starting ollama server..."
+    ollama serve > /tmp/ollama-serve.log 2>&1 &
+    sleep 3
+fi
+
+echo "Pulling Ollama model: $MODEL"
+ollama pull "$MODEL"

--- a/runs/omnisharp
+++ b/runs/omnisharp
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
 
+case "$(uname -s)" in
+    Darwin) ASSET="omnisharp-osx-arm64-net6.0.tar.gz" ;;
+    *) ASSET="omnisharp-linux-x64-net6.0.tar.gz" ;;
+esac
+
 mkdir -p ~/.omnisharp
 
 cd ~/.omnisharp
-curl -L https://github.com/OmniSharp/omnisharp-roslyn/releases/latest/download/omnisharp-linux-x64-net6.0.tar.gz -o omnisharp.tar.gz
+curl -L https://github.com/OmniSharp/omnisharp-roslyn/releases/latest/download/$ASSET -o omnisharp.tar.gz
 
 tar -xzf omnisharp.tar.gz
 rm omnisharp.tar.gz

--- a/runs/update-upgrade
+++ b/runs/update-upgrade
@@ -1,3 +1,6 @@
 #!/usr/bin/env bash
 
-sudo apt update && sudo apt upgrade -y
+case "$(uname -s)" in
+    Darwin) brew update && brew upgrade ;;
+    *) sudo apt update && sudo apt upgrade -y ;;
+esac

--- a/runs/zsh
+++ b/runs/zsh
@@ -1,6 +1,14 @@
 #!/usr/bin/env bash
 
-sudo apt install -y zsh
-hash -r
-sudo chsh -s $(which zsh)
+case "$(uname -s)" in
+    Darwin)
+        # macOS already ships zsh as the default login shell
+        ;;
+    *)
+        sudo apt install -y zsh
+        hash -r
+        sudo chsh -s $(which zsh)
+        ;;
+esac
+
 sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"

--- a/setup
+++ b/setup
@@ -1,20 +1,38 @@
 #!/usr/bin/env bash
-sudo apt -y update
+case "$(uname -s)" in
+    Darwin)
+        # Xcode Command Line Tools (Homebrew also pulls these in)
+        if ! xcode-select -p > /dev/null 2>&1; then
+            echo "Requesting Xcode Command Line Tools install..."
+            xcode-select --install || true
+        fi
 
-if ! command -v git &> /dev/null; then
-    sudo apt -y install git
-fi
+        # Homebrew
+        if ! command -v brew > /dev/null 2>&1; then
+            echo "Installing Homebrew..."
+            /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+        fi
+        eval "$(/opt/homebrew/bin/brew shellenv)"
 
-if [ ! -d $HOME/personal ]; then
-    mkdir $HOME/personal
-fi
+        if ! command -v git > /dev/null 2>&1; then
+            brew install git
+        fi
+        ;;
+    *)
+        sudo apt -y update
 
-if [ ! -d $HOME/.local/bin ]; then
-    mkdir $HOME/.local/bin
-fi
+        if ! command -v git &> /dev/null; then
+            sudo apt -y install git
+        fi
+        ;;
+esac
 
+mkdir -p $HOME/personal
 mkdir -p $HOME/.local/bin
-git clone https://github.com/kx0101/.dotfiles $HOME/personal/.dotfiles
+
+if [ ! -d $HOME/personal/.dotfiles ]; then
+    git clone https://github.com/kx0101/.dotfiles $HOME/personal/.dotfiles
+fi
 
 pushd $HOME/personal/.dotfiles
 ./run


### PR DESCRIPTION
Ports the dotfiles to macOS (Apple Silicon / M5 Pro, 48 GB) while keeping Linux fully working, using the same \`uname\` OS-detection already used by \`runs/dotnet\`.

## Modified
- \`setup\`: Homebrew + Xcode CLT on macOS, apt on Linux
- \`.zshrc\`: brew shellenv + per-OS paths; hardcoded proxy now Linux-only
- \`.tmux.conf\`: yank uses pbcopy on macOS, xclip on Linux
- \`dev-env\`: deploys Hammerspoon on macOS
- \`runs/*\`: Darwin brew branches (git, go, node, neovim, zsh, docker-desktop, ghostty, fonts, libs, omnisharp osx-arm64, netcoredbg osx-amd64 + Rosetta, update-upgrade)

## New
- \`hammerspoon/init.lua\`: ⌥Q Chrome, ⌥W Ghostty, ⌥E Slack, ⌥R Discord, ⌥F Spotify (ported from shortcuts.ahk)
- \`runs/ollama\`: Ollama + qwen2.5-coder:32b (overridable via \$OLLAMA_MODEL)
- \`runs/ai-clis\`: @github/copilot + @anthropic-ai/claude-code

## Verified
All scripts pass \`bash -n\`, Lua config valid, tmux config loads, every Homebrew cask/formula name confirmed via brew API.