### PR TITLE
[macOS] newcomer essentials: apps, AltTab, key repeat, Finder, option-as-alt

### DIFF
--- a/config
+++ b/config
@@ -11,6 +11,10 @@ font-family = "Adwaita Sans"
 
 keybind = ctrl+shift+f=toggle_fullscreen
 
+# macOS: send Alt/Meta from the Option key so terminal Alt-keybindings work
+# (this key is ignored on Linux)
+macos-option-as-alt = true
+
 # Black
 palette = 0=#26233a
 # Red

--- a/runs/apps
+++ b/runs/apps
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# GUI apps via Homebrew casks. No-op on Linux.
+# The ⌥ shortcuts in hammerspoon/init.lua expect these to exist.
+
+[ "$(uname -s)" = "Darwin" ] || exit 0
+
+apps=(
+    google-chrome   # ⌥Q  browser
+    slack           # ⌥E
+    discord         # ⌥R
+    spotify         # ⌥F
+    alt-tab         # Windows/Linux-style Alt-Tab: switch WINDOWS with previews
+)
+
+for a in "${apps[@]}"; do
+    brew install --cask "$a" || echo "  (skipped $a)"
+done
+
+echo "GUI apps installed. (Ghostty terminal comes from runs/ghostty.)"
+echo "Tip: AltTab's default trigger is ⌥Tab — change it in its settings if you like."

--- a/runs/macos-defaults
+++ b/runs/macos-defaults
@@ -31,8 +31,25 @@ if [ "${REDUCE_MOTION:-1}" = "1" ]; then
     defaults write com.apple.universalaccess reduceMotion -bool true
 fi
 
-killall Dock 2>/dev/null || true
+# --- Keyboard: essential for vim/nvim ---
+# Disable the press-and-hold accent popup so holding a key repeats it (hjkl)
+defaults write -g ApplePressAndHoldEnabled -bool false
+# Fast key repeat + short initial delay (2/15 are the fastest the System
+# Settings sliders expose)
+defaults write -g KeyRepeat -int 2
+defaults write -g InitialKeyRepeat -int 15
 
-echo "macOS animation tweaks applied."
-echo "Reduce Motion may need a logout/login to fully apply; if it doesn't stick,"
-echo "toggle it in System Settings > Accessibility > Display > Reduce Motion."
+# --- Finder quality-of-life (Linux-friendly) ---
+defaults write -g AppleShowAllExtensions -bool true
+defaults write com.apple.finder AppleShowAllFiles -bool true
+defaults write com.apple.finder ShowPathbar -bool true
+defaults write com.apple.finder ShowStatusBar -bool true
+# Search the current folder by default rather than the whole Mac
+defaults write com.apple.finder FXDefaultSearchScope -string "SCcf"
+
+killall Dock 2>/dev/null || true
+killall Finder 2>/dev/null || true
+
+echo "macOS tweaks applied (animations, keyboard repeat, Finder)."
+echo "Key repeat + Reduce Motion may need a logout/login to fully apply."
+echo "If Reduce Motion doesn't stick: System Settings > Accessibility > Display."


### PR DESCRIPTION
For a first-time macOS user coming from Linux. Builds on #15/#16.

- **runs/apps** (new): installs the GUI apps the ⌥ shortcuts target (Chrome/Slack/Discord/Spotify) plus **AltTab** (Windows/Linux-style Alt-Tab between windows with previews). Without this the shortcuts launched nothing.
- **runs/macos-defaults**: disables the press-and-hold accent popup and sets fast key repeat — essential for hjkl/nvim — plus Finder QoL (show extensions, hidden files, path/status bar, search current folder).
- **config** (Ghostty): `macos-option-as-alt = true` so terminal Alt-keybindings work (no-op on Linux).

All Darwin-guarded / no-op on Linux. Cask names verified via brew API.